### PR TITLE
Add support for the timeout request option

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -340,6 +340,7 @@ export class HTTP {
         this.request = deps.http.request(this.options, resolve)
       }
       this.request.on('error', reject)
+      this.request.on('timeout', reject)
       if (this.options.body && deps.isStream.readable(this.options.body)) {
         this.options.body.pipe(this.request)
       } else {


### PR DESCRIPTION
The timeout request option doesn't work without adding this event handler.
