### PR TITLE
fix(http.ts): fix TypeError on request timeout

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -302,7 +302,7 @@ export class HTTP<T> {
     this._errorRetries++
     const allowed = (err: IErrorWithCode): boolean => {
       if (this._errorRetries > 5) return false
-      if (!err.code) return false
+      if (!err || !err.code) return false
       if (err.code === 'ENOTFOUND') return true
       return require('is-retry-allowed')(err)
     }


### PR DESCRIPTION
When a request timeout occurs, I am seeing error `TypeError: Cannot read property 'code' of undefined` in `_maybeRetry`. This PR checks if `err` object exists before accessing property `err.code`.