### PR TITLE
feat!: adding no_proxy (and NO_PROXY) environment variable support

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -236,7 +236,7 @@ export class HTTP<T> {
     this.options.protocol = u.protocol || this.options.protocol
     this.options.host = u.hostname || this.ctor.defaults.host || 'localhost'
     this.options.path = u.path || '/'
-    this.options.agent = this.options.agent || deps.proxy.agent(this.secure)
+    this.options.agent = this.options.agent || deps.proxy.agent(this.secure, this.options.host)
     this.options.port = u.port || this.options.port || (this.secure ? 443 : 80)
   }
   get headers(): http.IncomingMessage['headers'] {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -73,3 +73,81 @@ describe('with http proxy only', () => {
     })
   })
 })
+
+describe('with no_proxy', () => {
+  beforeEach(() => {
+    Proxy.env.HTTP_PROXY = 'http://user:pass@foo.com'
+    Proxy.env.NO_PROXY = 'some.com,test-domain.com'
+  })
+
+  test('is an exact match of no_proxy', () => {
+    expect(Proxy.agent(false, 'test-domain.com')).toBeUndefined()
+  })
+
+  test('is a subdomain of no_proxy', () => {
+    expect(Proxy.agent(false, 'something.prod.test-domain.com')).toBeUndefined()
+  })
+
+  test('should be proxied', () => {
+    expect(Proxy.agent(false, 'proxied-domain.com')).toMatchObject({
+      options: {
+        proxy: {
+          host: 'foo.com',
+          port: '8080',
+          proxyAuth: 'user:pass',
+        },
+      },
+      proxyOptions: {
+        host: 'foo.com',
+        port: '8080',
+        proxyAuth: 'user:pass',
+      },
+    })
+  })
+})
+
+describe('proxy dodging', () => {
+  test('not set should proxy', () => {
+    Proxy.env.NO_PROXY = ''
+    expect(Proxy.shouldDodgeProxy('test-domain.com')).toBe(false)
+    expect(Proxy.shouldDodgeProxy('other-domain.com')).toBe(false)
+  })
+
+  test('wildcard proxies any', () => {
+    Proxy.env.NO_PROXY = '*'
+    expect(Proxy.shouldDodgeProxy('test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('anything.other-domain.com')).toBe(true)
+  })
+
+  test('exact domain should also match subdomains', () => {
+    Proxy.env.NO_PROXY = 'test-domain.com'
+    expect(Proxy.shouldDodgeProxy('test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('anything.test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('other-domain.com')).toBe(false)
+    expect(Proxy.shouldDodgeProxy('anything.other-domain.com')).toBe(false)
+  })
+
+  test('any sub domain should include the domain itself', () => {
+    Proxy.env.NO_PROXY = '.test-domain.com'
+    expect(Proxy.shouldDodgeProxy('test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('anything.test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('other-domain.com')).toBe(false)
+    expect(Proxy.shouldDodgeProxy('anything.other-domain.com')).toBe(false)
+  })
+
+  test('multiple domains', () => {
+    Proxy.env.NO_PROXY = '.test-domain.com, .other-domain.com'
+    expect(Proxy.shouldDodgeProxy('test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('anything.test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('other-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('anything.other-domain.com')).toBe(true)
+  })
+
+  test('match any subdomains', () => {
+    Proxy.env.NO_PROXY = '.test-domain.com, other-domain.com'
+    expect(Proxy.shouldDodgeProxy('test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('something.something-else.anything.test-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('other-domain.com')).toBe(true)
+    expect(Proxy.shouldDodgeProxy('something.anything.other-domain.com')).toBe(true)
+  })
+})


### PR DESCRIPTION
It is following the [convention of `curl`](https://github.com/curl/curl/issues/1208#issuecomment-272837735) as it seems not to have any RFC.
 regarding no_proxy