### PR TITLE
fix: support for `+json` suffix

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -389,7 +389,7 @@ export class HTTP<T> {
   private async _parse() {
     this.body = await concat(this.response) as T
     let type = this.response.headers['content-type'] ? deps.contentType.parse(this.response).type : ''
-    let json = type.startsWith('application/json') || type.startsWith('application/vnd.api+json') || type.includes('+json')
+    let json = type.startsWith('application/json') || type.includes('+json')
     if (json) this.body = JSONParse(this.body as any as string)
   }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -389,7 +389,7 @@ export class HTTP<T> {
   private async _parse() {
     this.body = await concat(this.response) as T
     let type = this.response.headers['content-type'] ? deps.contentType.parse(this.response).type : ''
-    let json = type.startsWith('application/json') || type.startsWith('application/vnd.api+json')
+    let json = type.startsWith('application/json') || type.startsWith('application/vnd.api+json') || type.includes('+json')
     if (json) this.body = JSONParse(this.body as any as string)
   }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -389,7 +389,7 @@ export class HTTP<T> {
   private async _parse() {
     this.body = await concat(this.response) as T
     let type = this.response.headers['content-type'] ? deps.contentType.parse(this.response).type : ''
-    let json = type.startsWith('application/json') || type.includes('+json')
+    let json = type.startsWith('application/json') || type.endsWith('+json')
     if (json) this.body = JSONParse(this.body as any as string)
   }
 


### PR DESCRIPTION
API such as Artifactory are answering suffixed Content Types that are
considered valid by [RFC6838](https://tools.ietf.org/html/rfc6838).

An example would be:
"application/vnd.org.jfrog.artifactory.search.MetadataSearchResult+json"

EDIT: Why `.includes('+json')` instead of `.endWith('+json')`, because a valid media type could specify some parameters after the suffix [sources](https://en.wikipedia.org/wiki/Media_type)