### PR TITLE
Stop Re-Stringifing Strings

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -421,7 +421,11 @@ export class HTTP<T> {
     }
 
     if (this.options.headers['content-type'] === 'application/json') {
-      this.options.body = JSON.stringify(body)
+      if (typeof body !== 'string') {
+        this.options.body = JSON.stringify(body)
+      } else {
+        this.options.body = body
+      }
     } else {
       this.options.body = body
     }


### PR DESCRIPTION
I spent a great deal of time debugging why 
```js
response = await HTTP.post(apiUrl, {
    body: JSON.stringify(requestPayload),
    headers: {
        'Content-Type': 'application/json'
    }
});
```
was sending a malformed body. I eventually removed `JSON.stringify()` from my payload and the request worked. Turns out there is no check for whether the body is a string or an object, so all strings are re-stringified, which messes up the body. This just adds a simple check to only stringifies non-bodies.