### PR TITLE
feat: remove sensitive headers for cross-origin redirects

### DIFF
--- a/src/http.test.ts
+++ b/src/http.test.ts
@@ -219,31 +219,223 @@ uh oh`)
     }
   })
 
-  test('follows redirect', async () => {
-    api.get('/foo1').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo2'})
-    api.get('/foo2').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo3'})
-    api.get('/foo3').reply(200, {success: true})
-    await HTTP.get('https://api.jdxcode.com/foo1')
-  })
-
-  test('follows redirect only 10 times', async () => {
-    api.get('/foo1').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo2'})
-    api.get('/foo2').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo3'})
-    api.get('/foo3').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo4'})
-    api.get('/foo4').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo5'})
-    api.get('/foo5').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo6'})
-    api.get('/foo6').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo7'})
-    api.get('/foo7').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo8'})
-    api.get('/foo8').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo9'})
-    api.get('/foo9').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo10'})
-    api.get('/foo10').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo11'})
-    api.get('/foo11').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo12'})
-    expect.assertions(1)
-    try {
-      await HTTP.get('https://api.jdxcode.com/foo1')
-    } catch (error: any) {
-      expect(error.message).toEqual('Redirect loop at https://api.jdxcode.com/foo11')
+  describe('redirect', () => {
+    const redirectHeaders = {
+      authorization: 'Bearer secret-token-123',
+      cookie: 'session=abc123; userid=456',
+      date: 'Tue, 07 Jul 2026 12:00:00 GMT',
+      'proxy-authorization': 'Basic xyz',
+      'x-addon-sso': 'sso-token',
     }
+
+    test('follows redirect', async () => {
+      api.get('/foo1').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo2'})
+      api.get('/foo2').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo3'})
+      api.get('/foo3').reply(200, {success: true})
+      await HTTP.get('https://api.jdxcode.com/foo1')
+    })
+
+    test('follows redirect only 10 times', async () => {
+      api.get('/foo1').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo2'})
+      api.get('/foo2').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo3'})
+      api.get('/foo3').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo4'})
+      api.get('/foo4').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo5'})
+      api.get('/foo5').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo6'})
+      api.get('/foo6').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo7'})
+      api.get('/foo7').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo8'})
+      api.get('/foo8').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo9'})
+      api.get('/foo9').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo10'})
+      api.get('/foo10').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo11'})
+      api.get('/foo11').reply(302, undefined, {Location: 'https://api.jdxcode.com/foo12'})
+      expect.assertions(1)
+      try {
+        await HTTP.get('https://api.jdxcode.com/foo1')
+      } catch (error: any) {
+        expect(error.message).toEqual('Redirect loop at https://api.jdxcode.com/foo11')
+      }
+    })
+
+    test('skips redirect if followRedirects is false', async () => {
+      const first = nock('https://api.jdxcode.com')
+        .get('/foo1')
+        .reply(302, undefined, {Location: 'https://api.jdxcode.com/foo2'})
+
+      const second = nock('https://api.jdxcode.com')
+        .get('/foo2')
+        .reply(200, {success: true})
+
+      const response = await HTTP.get('https://api.jdxcode.com/foo1', {followRedirects: false})
+
+      expect(first.isDone()).toBe(true)
+      expect(second.isDone()).toBe(false)
+      expect(response.statusCode).toBe(302)
+      expect(response.headers.location).toBe('https://api.jdxcode.com/foo2')
+    })
+
+    describe('removes sensitive headers for cross-origin redirects', () => {
+      test('host mismatch', async () => {
+        api
+          .get('/foo1')
+          .reply(302, undefined, {Location: 'https://docs.jdxcode.com/foo2'})
+
+        const differentHost = nock('https://docs.jdxcode.com')
+          .get('/foo2')
+          .reply(function () {
+            expect(this.req.headers.authorization).toBeUndefined()
+            expect(this.req.headers.cookie).toBeUndefined()
+            expect(this.req.headers['proxy-authorization']).toBeUndefined()
+            expect(this.req.headers['x-addon-sso']).toBeUndefined()
+            expect(this.req.headers.date).toBeDefined()
+
+            return [200, {success: true}]
+          })
+
+        await HTTP.get('https://api.jdxcode.com/foo1', {headers: redirectHeaders})
+
+        differentHost.done()
+      })
+
+      test('port mismatch', async () => {
+        api
+          .get('/foo1')
+          .reply(302, undefined, {Location: 'https://api.jdxcode.com:8080/foo2'})
+
+        const differentPort = nock('https://api.jdxcode.com:8080')
+          .get('/foo2')
+          .reply(function () {
+            expect(this.req.headers.authorization).toBeUndefined()
+            expect(this.req.headers.cookie).toBeUndefined()
+            expect(this.req.headers['proxy-authorization']).toBeUndefined()
+            expect(this.req.headers['x-addon-sso']).toBeUndefined()
+            expect(this.req.headers.date).toBeDefined()
+
+            return [200, {success: true}]
+          })
+
+        await HTTP.get('https://api.jdxcode.com/foo1', {headers: redirectHeaders})
+
+        differentPort.done()
+      })
+
+      test('scheme mismatch', async () => {
+        api
+          .get('/foo1')
+          .reply(302, undefined, {Location: 'http://api.jdxcode.com/foo2'})
+
+        const differentScheme = nock('http://api.jdxcode.com')
+          .get('/foo2')
+          .reply(function () {
+            expect(this.req.headers.authorization).toBeUndefined()
+            expect(this.req.headers.cookie).toBeUndefined()
+            expect(this.req.headers['proxy-authorization']).toBeUndefined()
+            expect(this.req.headers['x-addon-sso']).toBeUndefined()
+            expect(this.req.headers.date).toBeDefined()
+
+            return [200, {success: true}]
+          })
+
+        await HTTP.get('https://api.jdxcode.com/foo1', {headers: redirectHeaders})
+
+        differentScheme.done()
+      })
+    })
+
+    describe('preserves headers for same-origin redirects', () => {
+      test('absolute path', async () => {
+        api
+          .get('/foo1')
+          .reply(302, undefined, {Location: 'https://api.jdxcode.com/foo2'})
+
+        api
+          .get('/foo2')
+          .matchHeader('authorization', 'Bearer secret-token-123')
+          .matchHeader('cookie', 'session=abc123; userid=456')
+          .matchHeader('proxy-authorization', 'Basic xyz')
+          .matchHeader('x-addon-sso', 'sso-token')
+          .matchHeader('date', 'Tue, 07 Jul 2026 12:00:00 GMT')
+          .reply(200, {success: true})
+
+        await HTTP.get('https://api.jdxcode.com/foo1', {headers: redirectHeaders})
+      })
+
+      test('absolute path (non-default port)', async () => {
+        const extendedApi = nock('https://api.jdxcode.com:8080')
+          .get('/foo1')
+          .reply(302, undefined, {Location: 'https://api.jdxcode.com:8080/foo2'})
+
+        extendedApi
+          .get('/foo2')
+          .matchHeader('authorization', 'Bearer secret-token-123')
+          .matchHeader('cookie', 'session=abc123; userid=456')
+          .matchHeader('proxy-authorization', 'Basic xyz')
+          .matchHeader('x-addon-sso', 'sso-token')
+          .matchHeader('date', 'Tue, 07 Jul 2026 12:00:00 GMT')
+          .reply(200, {success: true})
+
+        await HTTP.get('https://api.jdxcode.com:8080/foo1', {headers: redirectHeaders})
+
+        extendedApi.done()
+      })
+
+      test('protocol-relative path', async () => {
+        api
+          .get('/foo1')
+          .reply(302, undefined, {Location: '//api.jdxcode.com/foo2'})
+
+        api
+          .get('/foo2')
+          .matchHeader('authorization', 'Bearer secret-token-123')
+          .matchHeader('cookie', 'session=abc123; userid=456')
+          .matchHeader('proxy-authorization', 'Basic xyz')
+          .matchHeader('x-addon-sso', 'sso-token')
+          .matchHeader('date', 'Tue, 07 Jul 2026 12:00:00 GMT')
+          .reply(200, {success: true})
+
+        await HTTP.get('https://api.jdxcode.com/foo1', {headers: redirectHeaders})
+      })
+
+      test('relative path', async () => {
+        const extendedApi = nock('https://api.jdxcode.com/v1/test')
+
+        extendedApi
+          .get('/foo1')
+          .reply(302, undefined, {Location: 'foo2'})
+
+        extendedApi
+          .get('/foo2')
+          .matchHeader('authorization', 'Bearer secret-token-123')
+          .matchHeader('cookie', 'session=abc123; userid=456')
+          .matchHeader('proxy-authorization', 'Basic xyz')
+          .matchHeader('x-addon-sso', 'sso-token')
+          .matchHeader('date', 'Tue, 07 Jul 2026 12:00:00 GMT')
+          .reply(200, {success: true})
+
+        await HTTP.get('https://api.jdxcode.com/v1/test/foo1', {headers: redirectHeaders})
+
+        extendedApi.done()
+      })
+
+      test('path-absolute path', async () => {
+        const extendedApi = nock('https://api.jdxcode.com/v1/test')
+
+        extendedApi
+          .get('/foo1')
+          .reply(302, undefined, {Location: '/foo2'})
+
+        api
+          .get('/foo2')
+          .matchHeader('authorization', 'Bearer secret-token-123')
+          .matchHeader('cookie', 'session=abc123; userid=456')
+          .matchHeader('proxy-authorization', 'Basic xyz')
+          .matchHeader('x-addon-sso', 'sso-token')
+          .matchHeader('date', 'Tue, 07 Jul 2026 12:00:00 GMT')
+          .reply(200, {success: true})
+
+        await HTTP.get('https://api.jdxcode.com/v1/test/foo1', {headers: redirectHeaders})
+
+        extendedApi.done()
+      })
+    })
   })
 })
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -330,7 +330,7 @@ export class HTTP<T> {
       }
     }
 
-    // Clear previous port so `set url()` derives the next hop's effective port
+    // Clear previous port so `set url()` derives the new port
     this.options.port = undefined
 
     this.url = redirectUrl
@@ -359,7 +359,7 @@ export class HTTP<T> {
 
   private _resolveRedirectUrl(redirectLocation: string) : {isSameOrigin: boolean, redirectUrl: string} {
     try {
-      // Build current absolute URL
+      // Build current URL
       const currentUrl = new URL(this.url)
       currentUrl.port = String(this.options.port)
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -314,20 +314,7 @@ export class HTTP<T> {
       this.headers.location[0] :
       this.headers.location
 
-    const shouldRewriteMethodToGet =
-      ((this.statusCode === 301 || this.statusCode === 302) && this.method === 'POST') ||
-      (this.statusCode === 303 && !(this.method === 'GET' || this.method === 'HEAD'))
-
     const isCrossOrigin = !this._isSameOriginRedirect(location)
-
-    if (shouldRewriteMethodToGet) {
-      this.options.method = 'GET'
-      // Remove body and corresponding headers for GET requests
-      delete this.options.body
-      delete this.options.headers['content-type']
-      delete this.options.headers['content-length']
-      delete this.options.headers['transfer-encoding']
-    }
 
     // Strip sensitive headers for cross-origin redirects
     if (isCrossOrigin) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -314,10 +314,10 @@ export class HTTP<T> {
       this.headers.location[0] :
       this.headers.location
 
-    const isCrossOrigin = !this._isSameOriginRedirect(location)
+    const {isSameOrigin, redirectUrl} = this._resolveRedirectUrl(location)
 
     // Strip sensitive headers for cross-origin redirects
-    if (isCrossOrigin) {
+    if (!isSameOrigin) {
       const sensitiveHeaders = [
         'authorization',
         'cookie',
@@ -330,7 +330,10 @@ export class HTTP<T> {
       }
     }
 
-    this.url = location
+    // Clear previous port so `set url()` derives the next hop's effective port
+    this.options.port = undefined
+
+    this.url = redirectUrl
     await this._request()
   }
 
@@ -354,26 +357,27 @@ export class HTTP<T> {
     throw err
   }
 
-  /**
-   * Check if a redirect URL is same-origin with the current URL.
-   * Relative URLs are resolved against the current URL before comparison.
-   *
-   * @param redirectLocation - The Location header value from the redirect response
-   * @returns true if same-origin, false if cross-origin
-   */
-  private _isSameOriginRedirect(redirectLocation: string): boolean {
+  private _resolveRedirectUrl(redirectLocation: string) : {isSameOrigin: boolean, redirectUrl: string} {
     try {
       // Build current absolute URL
       const currentUrl = new URL(this.url)
+      currentUrl.port = String(this.options.port)
 
       // Resolve redirect location against current URL
       // This handles absolute, protocol-relative, path-absolute, and path-relative URLs
       const redirectUrl = new URL(redirectLocation, currentUrl)
 
-      return currentUrl.origin === redirectUrl.origin
+      return {
+        isSameOrigin: currentUrl.origin === redirectUrl.origin,
+        redirectUrl: redirectUrl.toString(),
+      }
     } catch (error) {
       debug(`Failed to resolve redirect URL: ${redirectLocation}`, error)
-      return false
+
+      return {
+        isSameOrigin: false,
+        redirectUrl: redirectLocation,
+      }
     }
   }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -68,7 +68,6 @@ function caseInsensitiveObject(): { [k: string]: any } {
     },
     deleteProperty: (t, k: string) => {
       k = lowercaseKey(k)
-      if (k in t) return false
       return delete t[k]
     },
     has: (t, k) => {
@@ -303,14 +302,52 @@ export class HTTP<T> {
     this._redirectRetries++
     if (this._redirectRetries > 10) throw new Error(`Redirect loop at ${this.url}`)
     if (!this.headers.location) throw new Error(`Redirect from ${this.url} has no location header`)
-    const location = this.headers.location
-    if (Array.isArray(location)) {
-      this.url = location[0]
-    } else {
-      this.url = location
+
+    const location = Array.isArray(this.headers.location) ?
+      this.headers.location[0] :
+      this.headers.location
+
+    const isCrossOrigin = !this._isSameOrigin(location)
+
+    // Strip sensitive headers for cross-origin redirects
+    if (isCrossOrigin) {
+      const sensitiveHeaders = [
+        'authorization',
+        'cookie',
+        'proxy-authorization',
+        'x-addon-sso',
+      ]
+
+      for (const header of sensitiveHeaders) {
+        delete this.options.headers[header]
+      }
     }
 
+    this.url = location
     await this._request()
+  }
+
+  /**
+   * Check if a redirect URL is same-origin with the current URL.
+   * Relative URLs are resolved against the current URL before comparison.
+   *
+   * @param redirectLocation - The Location header value from the redirect response
+   * @returns true if same-origin, false if cross-origin
+   */
+  private _isSameOrigin(redirectLocation: string): boolean {
+    try {
+      // Build current absolute URL
+      const currentUrl = new URL(this.url)
+
+      // Resolve redirect location against current URL
+      // This handles absolute, protocol-relative, path-absolute, and path-relative URLs
+      const redirectUrl = new URL(redirectLocation, currentUrl)
+
+      return currentUrl.origin === redirectUrl.origin
+    } catch (error) {
+      debug(`Failed to resolve redirect URL: ${redirectLocation}`, error)
+      return false
+    }
   }
 
   async _maybeRetry(err: Error) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -293,12 +293,11 @@ export class HTTP<T> {
     if (this._shouldParseResponseBody) await this._parse()
     this._debugResponse()
 
-    if (this._responseRedirect && this.options.followRedirects !== false) {
-      return this._redirect()
+    if (this._responseRedirect) {
+      return this.options.followRedirects !== false ? this._redirect() : undefined
     }
 
-    // Don't throw error for redirects when followRedirects is false
-    if (!this._responseOK && !(this._responseRedirect && this.options.followRedirects === false)) {
+    if (!this._responseOK) {
       throw new HTTPError(this)
     }
 
@@ -314,10 +313,13 @@ export class HTTP<T> {
       this.headers.location[0] :
       this.headers.location
 
-    const isNonPreservingStatusCode = [301, 302, 303].includes(this.statusCode)
-    const isCrossOrigin = !this._isSameOrigin(location)
+    const shouldRewriteMethodToGet =
+      ((this.statusCode === 301 || this.statusCode === 302) && this.method === 'POST') ||
+      (this.statusCode === 303 && !(this.method === 'GET' || this.method === 'HEAD'))
 
-    if (isNonPreservingStatusCode && this.method !== 'GET' && this.method !== 'HEAD') {
+    const isCrossOrigin = !this._isSameOriginRedirect(location)
+
+    if (shouldRewriteMethodToGet) {
       this.options.method = 'GET'
       // Remove body and corresponding headers for GET requests
       delete this.options.body
@@ -351,7 +353,7 @@ export class HTTP<T> {
    * @param redirectLocation - The Location header value from the redirect response
    * @returns true if same-origin, false if cross-origin
    */
-  private _isSameOrigin(redirectLocation: string): boolean {
+  private _isSameOriginRedirect(redirectLocation: string): boolean {
     try {
       // Build current absolute URL
       const currentUrl = new URL(this.url)

--- a/src/http.ts
+++ b/src/http.ts
@@ -37,6 +37,7 @@ export type FullHTTPRequestOptions = http.ClientRequestArgs & {
   body?: any
   partial?: boolean
   headers: http.OutgoingHttpHeaders
+  followRedirects?: boolean
 }
 
 export type HTTPRequestOptions = Partial<FullHTTPRequestOptions>
@@ -101,6 +102,7 @@ export class HTTP<T> {
     partial: false,
     headers: {},
     timeout: 60 * 1000,
+    followRedirects: true,
   }
 
   static create(options: HTTPRequestOptions = {}): typeof HTTP {
@@ -290,8 +292,13 @@ export class HTTP<T> {
 
     if (this._shouldParseResponseBody) await this._parse()
     this._debugResponse()
-    if (this._responseRedirect) return this._redirect()
-    if (!this._responseOK) {
+
+    if (this._responseRedirect && this.options.followRedirects !== false) {
+      return this._redirect()
+    }
+
+    // Don't throw error for redirects when followRedirects is false
+    if (!this._responseOK && !(this._responseRedirect && this.options.followRedirects === false)) {
       throw new HTTPError(this)
     }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -294,7 +294,8 @@ export class HTTP<T> {
     this._debugResponse()
 
     if (this._responseRedirect) {
-      return this.options.followRedirects !== false ? this._redirect() : undefined
+      if (this.options.followRedirects === false) return
+      return this._redirect()
     }
 
     if (!this._responseOK) {
@@ -346,6 +347,26 @@ export class HTTP<T> {
     await this._request()
   }
 
+  async _maybeRetry(err: Error) {
+    this._errorRetries++
+    const allowed = (err: IErrorWithCode): boolean => {
+      if (this._errorRetries > 5) return false
+      if (!err || !err.code) return false
+      if (err.code === 'ENOTFOUND') return true
+      return require('is-retry-allowed')(err)
+    }
+
+    if (allowed(err)) {
+      const noise = Math.random() * 100
+      // tslint:disable-next-line
+      await this._wait(((1 << this._errorRetries) * 100) + noise)
+      await this._request()
+      return
+    }
+
+    throw err
+  }
+
   /**
    * Check if a redirect URL is same-origin with the current URL.
    * Relative URLs are resolved against the current URL before comparison.
@@ -367,26 +388,6 @@ export class HTTP<T> {
       debug(`Failed to resolve redirect URL: ${redirectLocation}`, error)
       return false
     }
-  }
-
-  async _maybeRetry(err: Error) {
-    this._errorRetries++
-    const allowed = (err: IErrorWithCode): boolean => {
-      if (this._errorRetries > 5) return false
-      if (!err || !err.code) return false
-      if (err.code === 'ENOTFOUND') return true
-      return require('is-retry-allowed')(err)
-    }
-
-    if (allowed(err)) {
-      const noise = Math.random() * 100
-      // tslint:disable-next-line
-      await this._wait(((1 << this._errorRetries) * 100) + noise)
-      await this._request()
-      return
-    }
-
-    throw err
   }
 
   private _renderStatus(code: number) {

--- a/src/http.ts
+++ b/src/http.ts
@@ -307,7 +307,17 @@ export class HTTP<T> {
       this.headers.location[0] :
       this.headers.location
 
+    const isNonPreservingStatusCode = [301, 302, 303].includes(this.statusCode)
     const isCrossOrigin = !this._isSameOrigin(location)
+
+    if (isNonPreservingStatusCode && this.method !== 'GET' && this.method !== 'HEAD') {
+      this.options.method = 'GET'
+      // Remove body and corresponding headers for GET requests
+      delete this.options.body
+      delete this.options.headers['content-type']
+      delete this.options.headers['content-length']
+      delete this.options.headers['transfer-encoding']
+    }
 
     // Strip sensitive headers for cross-origin redirects
     if (isCrossOrigin) {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR fixes a security vulnerability where HTTP redirects automatically forwarded sensitive credential headers to cross-origin destinations.

**New Feature:**
- Add `followRedirects: boolean` as a HTTP Request Option. Allows users to turn off automatic redirects (default: `true`).

**Security Fix:**
- Strip sensitive headers (`authorization`, `cookie`, `proxy-authorization`, `x-addon-sso`) when redirecting to a different origin

**Code Quality:**
- Fix bug in `deleteProperty` (incorrectly returned false for existing properties without deleting the entry)

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->
We'll need three separate terminals

**Steps**:
1. Pull down this branch
2. `yarn install`

**Test 1:** Cross-origin redirect strips sensitive headers
``` bash
node -e "
const http = require('http')
const httpModule = require('./lib/http')
const HTTP = httpModule.default || httpModule

const HOST = '127.0.0.1'
const PORT = 18081
const REDIRECT_TARGET = 'http://127.0.0.1:18082/'

const trustedServer = http
  .createServer((req, res) => {
    res.statusCode = 302
    res.setHeader('Location', REDIRECT_TARGET)
    console.log(\`[trusted \${HOST}:\${PORT}] redirecting from \${req.url} to \${REDIRECT_TARGET}\`)
    res.end('ok')
  })
  .listen(PORT, HOST, () => {
    console.log(\`[trusted \${HOST}:\${PORT}] listening\`)
  })

const PORT2 = 18082

const attackerServer = http
  .createServer((req, res) => {
    const auth = req.headers.authorization || ''
    res.statusCode = 200
    console.log(\`[attacker \${HOST}:\${PORT2}] got authorization=\"\${auth}\"\`)
    res.end('ok')
  })
  .listen(PORT2, HOST, () => {
    console.log(\`[attacker \${HOST}:\${PORT2}] listening\`)
  })

const url = 'http://127.0.0.1:18081/'
const token = 'Bearer SUPER-SECRET-TOKEN-abc123'

HTTP.get(url, {
  headers: { authorization: token },
})
  .then((response) => {
    console.log(\`[client] status=\${response.statusCode}\`)
    trustedServer.close()
    attackerServer.close()
  })
  .catch((error) => {
    console.error('[client] error:', error)
    process.exitCode = 1
  })
"
```

**Expected Output:**
```bash
[trusted 127.0.0.1:18081] listening
[attacker 127.0.0.1:18082] listening
[trusted 127.0.0.1:18081] redirecting from / to http://127.0.0.1:18082/
[attacker 127.0.0.1:18082] got authorization=""
[client] status=200
```

**Test 2:** Same-origin maintains sensitive headers
```bash
node -e "
const http = require('http')
const httpModule = require('./lib/http')
const HTTP = httpModule.default || httpModule

const HOST = '127.0.0.1'
const PORT = 18081
const ORIGIN = \`http://\${HOST}:\${PORT}\`

const trustedServer = http.createServer((req, res) => {
  if (req.url === '/start') {
    const target = \`\${ORIGIN}/final\` // same-origin redirect
    console.log(\`[server] \${req.method} /start -> 302 \${target}\`)
    res.statusCode = 302
    res.setHeader('Location', target)
    res.end('redirecting')
    return
  }

  if (req.url === '/final') {
    const auth = req.headers.authorization || ''
    console.log(\`[server] \${req.method} /final authorization=\\\"\${auth}\\\"\`)
    res.statusCode = 200
    res.end('ok')
    return
  }

  res.statusCode = 404
  res.end('not found')
}).listen(PORT, HOST, async () => {
  console.log(\`[server] listening on \${ORIGIN}\`)

  try {
    const response = await HTTP.get(\`\${ORIGIN}/start\`, {
      headers: { authorization: 'Bearer SUPER-SECRET-TOKEN-abc123' },
    })
    console.log(\`[client] status=\${response.statusCode}\`)
    trustedServer.close()
  } catch (error) {
    console.error('[client] error:', error)
    process.exitCode = 1
  }
})
"
```

**Expected Output:**
```bash
[server] listening on http://127.0.0.1:18081
[server] GET /start -> 302 http://127.0.0.1:18081/final
[server] GET /final authorization="Bearer SUPER-SECRET-TOKEN-abc123"
[client] status=200
```

**Test 3:** followRedirect: false
```bash
node -e "
const http = require('http')
const httpModule = require('./lib/http')
const HTTP = httpModule.default || httpModule

const HOST = '127.0.0.1'
const TRUSTED_PORT = 18081
const ATTACKER_PORT = 18082
const REDIRECT_TARGET = \`http://\${HOST}:\${ATTACKER_PORT}/\`

let attackerHit = false

const trusted = http.createServer((req, res) => {
  res.statusCode = 302
  res.setHeader('Location', REDIRECT_TARGET)
  console.log(\`[trusted] redirecting \${req.url} -> \${REDIRECT_TARGET}\`)
  res.end('redirect')
}).listen(TRUSTED_PORT, HOST, () => {
  console.log('[trusted] listening')
})

const attacker = http.createServer((req, res) => {
  attackerHit = true
  console.log('[attacker] SHOULD NOT BE HIT')
  res.statusCode = 200
  res.end('ok')
}).listen(ATTACKER_PORT, HOST, async () => {
  console.log('[attacker] listening')

  try {
    const r = await HTTP.get(\`http://\${HOST}:\${TRUSTED_PORT}/\`, {
      followRedirects: false,
      headers: { authorization: 'Bearer TOKEN' },
    })

    console.log(\`[client] status=\${r.statusCode}\`)
    console.log(\`[client] location=\${r.headers.location}\`)
    console.log(\`[client] redirected=\${attackerHit}\`)
  } catch (e) {
    console.error('[client] error:', e)
  } finally {
    trusted.close()
    attacker.close()
  }
})
"
```

**Expected Outcome:**
```bash
[trusted] listening
[attacker] listening
[trusted] redirecting / -> http://127.0.0.1:18082/
[client] status=302
[client] location=http://127.0.0.1:18082/
[client] redirected=false
```

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23264766](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dd9KEYAY/view)